### PR TITLE
Use Redis to cache session tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 before_script:
     - mv config.py.dist config.py
+    - echo "TESTING = True" >> config.py
 
 script:
     - flake8 app

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can access the webpage at http://localhost:5000. The login page can be found
 at http://localhost:5000/login. To submit a time, visit
 http://localhost:5000/submit.
 
-To run tests, do:
+To run tests, first set "TESTING" in config.py to "True", then do:
 ```
 (venv) $ nosetests
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,9 @@
 from flask import Flask
+from redis import StrictRedis
 
 app = Flask(__name__)
 app.config.from_object('config')
+
+redis = StrictRedis(host='redis')
 
 from app import views  # NOQA flake8 ignore

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
 from flask import Flask
-from redis import StrictRedis
+from app import redis_wrapper
 
 app = Flask(__name__)
 app.config.from_object('config')
 
-redis = StrictRedis(host='redis')
+redis = redis_wrapper.RedisWrapper(app.config['TESTING'])
 
 from app import views  # NOQA flake8 ignore

--- a/app/redis_wrapper.py
+++ b/app/redis_wrapper.py
@@ -1,0 +1,43 @@
+from redis import StrictRedis
+
+
+# Redis wrapper class for convenience when running unit tests
+class RedisWrapper():
+
+    def __init__(self, test=True):
+        self.test = test
+
+        # If testing mode is active, use a dict instead of trying to connect
+        if not test:
+            self.redis = StrictRedis(host='redis')
+        else:
+            self.redis = dict()
+
+    def get(self, name):
+        if not self.test:
+            return self.redis.get(name)
+        else:
+            return self.redis[name]
+
+    def set(self, name, value):
+        if not self.test:
+            self.redis.set(name, value)
+        else:
+            self.redis[name] = value
+
+    def exists(self, name):
+        if not self.test:
+            return self.redis.exists(name)
+        else:
+            return name in self.redis
+
+    def expireat(self, name, when):
+        # No such thing as expiry for testing mode
+        if not self.test:
+            self.redis.expireat(name, when)
+
+    def delete(self, name):
+        if not self.test:
+            self.redis.delete(name)
+        else:
+            self.redis.pop(name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,9 @@ services:
         command: python /opt/code/run.py
         ports:
             - "5000:5000"
+
+        depends_on:
+            - redis
+
+    redis:
+        image: redis

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -3,3 +3,4 @@ pymesync==0.1.3
 flake8==2.5.4
 nose==1.3.7
 Flask-WTF==0.12
+redis==2.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pymesync==0.1.3
 flake8==2.5.4
 nose==1.3.7
 Flask-WTF==0.12
+redis==2.10.5

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,5 +1,5 @@
 import unittest
-from app import app
+from app import app, redis
 from flask import url_for
 import pymesync
 import datetime
@@ -91,14 +91,14 @@ class LoginTestCase(unittest.TestCase):
         self.login()
 
         # Make sure username and token stored in session
-        assert 'username' in self.sess
-        assert 'token' in self.sess
+        assert 'user' in self.sess
 
         # Make sure username is correct
-        assert self.sess['username'] == self.username
+        assert self.sess['user'] == self.username
 
         # Make sure token is valid
-        ts = pymesync.TimeSync(self.baseurl, token=self.sess['token'],
+        ts = pymesync.TimeSync(self.baseurl,
+                               redis.get('{}:token'.format(self.username)),
                                test=True)
         assert type(ts.token_expiration_time()) is datetime.datetime
 


### PR DESCRIPTION
This PR adds a Redis container to Docker and changes the behavior of the app to store authentication tokens in the database instead of in the session. In testing mode, this information is stored in a Python dict instead of in a Redis database. This simplifies token expiry and allows for other potential uses for Redis in the future.

Closes #19 and potentially #18 
