### PR TITLE
Update Pymesync version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.10.1
-pymesync==0.1.3
+pymesync==0.1.4
 flake8==2.5.4
 nose==1.3.7
 Flask-WTF==0.12


### PR DESCRIPTION
Updates Pymesync so we can use token_expiration_time() without getting errors.
