### PR TITLE
Changed view_times to not get times until form submission

### DIFF
--- a/app/templates/view_times.html
+++ b/app/templates/view_times.html
@@ -16,7 +16,10 @@ function clearForm(form)
         }
     }
 
-    form.submit();
+    var oldBody = document.getElementsByTagName('tbody')[0];
+    var newBody = document.createElement('tbody');
+
+    oldBody.parentNode.replaceChild(newBody, oldBody);
 }
 </script>
 {% endblock %}
@@ -48,22 +51,24 @@ function clearForm(form)
                 </tr>
             </thead>
 
-            {% for t in times %}
-            <tr>
-            {% if t['user'] == user or admin %}
-                <td><a href="{{ url_for('edit_time', time=t['uuid']) }}">EDIT</a></td>
-            {% else %}
-                <td></td>
-            {% endif %}
-                <td>{{ t['user'] }}</td>
-                <td>{{ t['duration'] | hms_filter }}</td>
-                <td>{{ t['date_worked'] }}</td>
-                <td>{{ t['project'] | join(' ') }}</td>
-                <td>{{ t['activities'] | join(' ') }}</td>
-                <td>{{ t['issue_uri'] }}</td>
-                <td>{{ t['notes'] }}</td>
-            </tr>
-            {% endfor %}
+            <tbody>
+                {% for t in times %}
+                <tr>
+                {% if t['user'] == user or is_admin %}
+                    <td><a href="{{ url_for('edit_time', time=t['uuid']) }}">EDIT</a></td>
+                {% else %}
+                    <td></td>
+                {% endif %}
+                    <td>{{ t['user'] }}</td>
+                    <td>{{ t['duration'] | hms_filter }}</td>
+                    <td>{{ t['date_worked'] }}</td>
+                    <td>{{ t['project'] | join(' ') }}</td>
+                    <td>{{ t['activities'] | join(' ') }}</td>
+                    <td>{{ t['issue_uri'] }}</td>
+                    <td>{{ t['notes'] }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
         </table>
     </div>
 {% endblock %}

--- a/app/views/view_times.py
+++ b/app/views/view_times.py
@@ -24,6 +24,9 @@ def view_times():
     # Dictionary to store filter parameters
     query = dict()
 
+    # List of times
+    times = list()
+
     # If the form has been submitted and validated use the form's parameters
     if form.validate_on_submit():
         req_form = request.form
@@ -46,14 +49,15 @@ def view_times():
         if end:
             query['end'] = [end]
 
+        times = ts.get_times(query_parameters=query)
+
+        # Show any errors
+        if error_message(times):
+            times = list()
+
     # If the form's parameters are not valid, tell the user
     elif request.method == 'POST' and not form.validate():
         flash("Invalid form input")
 
-    times = ts.get_times(query_parameters=query)
-
-    # Show any errors
-    error_message(times)
-
     return render_template('view_times.html', form=form, times=times,
-                           user=user['username'], admin=user['site_admin'])
+                           user=user['username'], is_admin=user['site_admin'])


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #62 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] The `/times` endpoint no longer makes a Pymesync call on initial page load. As a result, accessing the page with tons of time entries in TimeSync no longer takes forever every single time.
- [X] The "clear" button now clears time entries in the table as well as form fields.
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run the app, log in, and go to the `/times` endpoint
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ nosetests
............................
----------------------------------------------------------------------
Ran 28 tests in 0.556s

OK
```

@osuosl/devs
