### PR TITLE
Added extra config file warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     - pip install -r requirements.txt
 
 before_script:
-    - mv config.py.dist config.py
+    - sed 's/http/https/g' config.py.dist > config.py
 
 script:
     - flake8 app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,30 @@
+import sys
+
 from flask import Flask
 
 app = Flask(__name__, static_folder="static")
-app.config.from_object('config')
+
+try:
+    app.config.from_object('config')
+except ImportError as e:
+    print e
+    print 'Error loading configuration!'
+    print 'Does the file exist?'
+    sys.exit(1)
+
+# Do some config checks
+if app.config.get('TIMESYNC_URL') == 'http://timesync.example.com/':
+    print 'ERROR: Configuration option "TIMESYNC_URL" not set'
+    print '       Please set "TIMESYNC_URL" to the URL of your TimeSync server'
+    sys.exit(1)
+
+if app.config.get('SECRET_KEY') == 'secret':
+    print 'WARNING: "SECRET_KEY" hasn\'t been set! If you want to use session'
+    print '         encryption, you should set it!'
+
+if app.config.get('TESTING'):
+    print 'WARNING: In testing mode, the app probably won\'t behave quite'
+    print '         like you would expect it to. You have been warned!'
 
 from app.views import index, admin, create_time, delete_time  # NOQA flake8 ignore
 from app.views import login, logout, view_times, edit_time  # NOQA flake8 ignore

--- a/config.py.dist
+++ b/config.py.dist
@@ -1,6 +1,8 @@
 import os
 
 DEBUG = False
+
+# Don't set this by hand!
 TESTING = False
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #98 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] If the config file doesn't exist, tell the user
- [X] Errors and warnings are now displayed if certain configuration options (TIMESYNC_URL, SECRET_KEY, TESTING) haven't been set/have been set to things that are probably bad.
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. If `config.py` already exists, run `rm config.py config.pyc`
2. Run `docker-compose up` and see that the app exits after telling you that it couldn't load the configuration file
3. Run `cp config.py.dist config.py` and then `docker-compose up` again and see that you're given an error saying that you haven't set TIMESYNC_URL
4. Edit config.py and set `TIMESYNC_URL = "http://timesync-staging.osuosl.org/v0"` as well as `TESTING = True`
5. Run the app again and see that you're given two warnings about `TESTING` and `SECRET_KEY`.
6. Set `TESTING = False` and `SECRET_KEY = "supersecret"` and see that you aren't given any warnings when running the app again.
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
...
app_1  | ImportError: No module named config
app_1  | Error loading configuration!
app_1  | Does the file exist?
timesyncfrontendflask_app_1 exited with code 1
```

```
app_1  | ERROR: Configuration option "TIMESYNC_URL" not set
app_1  |        Please set "TIMESYNC_URL" to the URL of your TimeSync server
timesyncfrontendflask_app_1 exited with code 1
```

```
app_1  | WARNING: "SECRET_KEY" hasn't been set! If you want to use session
app_1  |          encryption, you should set it!
app_1  | WARNING: In testing mode, the app probably won't behave quite
app_1  |          like you would expect it to. You have been warned!
```

```
app_1  |  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
```

@osuosl/devs
