### PR TITLE
Add support for project default activities

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -40,14 +40,15 @@ class FilterTimesForm(Form):
 
 
 class CreateActivityForm(Form):
-    name = StringField('Activity Name:')
-    slug = StringField('Activity Slug:')
+    name = StringField('Activity Name:', validators=[DataRequired()])
+    slug = StringField('Activity Slug:', validators=[DataRequired()])
 
 
 class CreateProjectForm(Form):
-    uri = StringField('URI:', validators=[URL()])
-    name = StringField('Name:')
-    slugs = StringField('Slugs:')
+    uri = StringField('URI:', validators=[URL(), DataRequired()])
+    name = StringField('Name:', validators=[DataRequired()])
+    slugs = StringField('Slugs:', validators=[DataRequired()])
+    default_activity = SelectField("Default Activity:")
     members = SelectMultipleField('Members')
     managers = SelectMultipleField('Managers')
     spectators = SelectMultipleField('Spectators')
@@ -66,8 +67,8 @@ class FilterActivitiesForm(Form):
 
 
 class CreateUserForm(Form):
-    username = StringField('Username:')
-    password = PasswordField('Password:')
+    username = StringField('Username:', validators=[DataRequired()])
+    password = PasswordField('Password:', validators=[DataRequired()])
     display_name = StringField('Display Name:')
     email = StringField('Email:')
     site_admin = BooleanField('Site Admin:')

--- a/app/templates/create_project.html
+++ b/app/templates/create_project.html
@@ -7,6 +7,7 @@
         <p>{{ form.uri.label }} {{ form.uri }}</p>
         <p>{{ form.name.label }} {{ form.name }}</p>
         <p>{{ form.slugs.label }} {{ form.slugs }}</p>
+        <p>{{ form.default_activity.label }} {{ form.default_activity }}</p>
         <p>{{ form.members.label }} {{ form.members }}</p>
         <p>{{ form.managers.label }} {{ form.managers }}</p>
         <p>{{ form.spectators.label }} {{ form.spectators }}</p>

--- a/app/templates/create_time.html
+++ b/app/templates/create_time.html
@@ -1,6 +1,32 @@
 {% extends "layout.html" %}
 
 {% block title %} Submit Times {% endblock %}
+
+{% block imports %}
+<script type="text/javascript" src="{{ url_for('static', filename='lib/jquery-3.1.0.min.js') }}"></script>
+{% endblock %}
+
+{% block scripts %}
+<script>
+var default_activities = {{ default_activities | safe }};
+
+$(document).ready(function() {
+    $("#project").change(function() {
+        var project_slug = $(this).find("option:selected").attr("value");
+
+        // Clear currently selected activities
+        $("#activities option").prop("selected", false);
+
+        if (project_slug in default_activities) {
+            var default_activity = default_activities[project_slug];
+
+            $("#activities option[value=" + default_activity + "]").prop("selected", true);
+        }
+    });
+});
+</script>
+{% endblock %}
+
 {% block body %}
     <form method="POST">
         {{ form.csrf_token }}

--- a/app/templates/edit_project.html
+++ b/app/templates/edit_project.html
@@ -7,6 +7,7 @@
         <p>{{ form.uri.label }} {{ form.uri }}</p>
         <p>{{ form.name.label }} {{ form.name }}</p>
         <p>{{ form.slugs.label }} {{ form.slugs }}</p>
+        <p>{{ form.default_activity.label }} {{ form.default_activity }}</p>
         <p>{{ form.members.label }} {{ form.members }}</p>
         <p>{{ form.managers.label }} {{ form.managers }}</p>
         <p>{{ form.spectators.label }} {{ form.spectators }}</p>

--- a/app/templates/view_projects.html
+++ b/app/templates/view_projects.html
@@ -50,6 +50,7 @@ $(document).ready(function() {
             <thead>
                 <tr>
                     <th class="alpha">Name</th>
+                    <th class="alpha">Default Activity</th>
                     <th class="list">Slugs</th>
                     <th class="list">Members</th>
                     <th class="list">Managers</th>
@@ -61,6 +62,7 @@ $(document).ready(function() {
             {% for p in projects %}
             <tr>
                 <td>{{ p['name'] }}</td>
+                <td>{{ p['default_activity'] }}</td>
                 <td>{{ p['slugs'] | join(' ') }}</td>
                 <td>{{ p['members'] | join(' ') }}</td>
                 <td>{{ p['managers'] | join(' ') }}</td>

--- a/app/views/create_project.py
+++ b/app/views/create_project.py
@@ -28,6 +28,10 @@ def create_project():
     for user in users:
         usernames.append((user['username'], user['display_name']))
 
+    form.default_activity.choices = [('', '')]
+    form.default_activity.choices += [(a['slug'], a['name'])
+                                      for a in session['user']['activities']]
+
     # Fill the multi-select boxes with usernames
     # In order to be able to select users for each permission, you must have a
     # list of users

--- a/app/views/create_time.py
+++ b/app/views/create_time.py
@@ -2,6 +2,7 @@ from flask import session, redirect, url_for, request, render_template, flash
 from app import app, forms
 from app.util import is_logged_in, error_message, decrypter
 import pymesync
+import json
 
 
 @app.route('/times/create/', methods=['GET', 'POST'])
@@ -21,10 +22,15 @@ def create_time():
                            test=app.config['TESTING'],
                            token=token)
 
-    form.project.choices = [(p['slugs'][0], p['name'])
-                            for p in session['user']['projects']]
+    form.project.choices = [('', '')]
+    form.project.choices += [(p['slugs'][0], p['name'])
+                             for p in session['user']['projects']]
     form.activities.choices = [(a['slug'], a['name'])
                                for a in session['user']['activities']]
+
+    default_activities = {p['slugs'][0]: p['default_activity']
+                          for p in session['user']['projects']
+                          if p['default_activity']}
 
     # If form submitted (POST)
     if form.validate_on_submit():
@@ -71,4 +77,5 @@ def create_time():
             ), 'error')
 
     # If not submitted (GET)
-    return render_template('create_time.html', form=form)
+    return render_template('create_time.html', form=form,
+                           default_activities=json.dumps(default_activities))

--- a/app/views/edit_project.py
+++ b/app/views/edit_project.py
@@ -37,6 +37,11 @@ def edit_project():
     elif not user['site_admin']:
         return "Permission denied", 403
 
+    if 'default_activity' in project:
+        default_activity = str(project['default_activity'])
+    else:
+        default_activity = ''
+
     members = []
     managers = []
     spectators = []
@@ -62,6 +67,7 @@ def edit_project():
         "members": members,
         "managers": managers,
         "spectators": spectators,
+        "default_activity": default_activity,
         "name": name,
         "slugs": slugs,
         "uri": ''
@@ -71,6 +77,10 @@ def edit_project():
         project_data['uri'] = str(project['uri'])
 
     form = forms.CreateProjectForm(data=project_data)
+
+    form.default_activity.choices = [('', '')]
+    form.default_activity.choices += [(a['slug'], a['name'])
+                                      for a in session['user']['activities']]
 
     # Enter choices
     form.members.choices = usernames

--- a/app/views/view_times.py
+++ b/app/views/view_times.py
@@ -36,7 +36,7 @@ def view_times():
     form.users.choices = [(u['username'], u['username'])
                           for u in session['users']]
     form.projects.choices = [(p['slugs'][0], p['name'])
-                             for p in session['projects']]
+                             for p in session['user']['projects']]
     form.activities.choices = [(a['slug'], a['name'])
                                for a in session['user']['activities']]
 

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -40,6 +40,7 @@ class SubmitTestCase(unittest.TestCase):
             uri="http://github.com",
             name="Github",
             slugs="git, hub, gh",
+            default_activity="development",
             users="{'tschuy': {'member': True, 'spectator': False, 'manager': \
                 True}}"
         ), follow_redirects=True)
@@ -68,8 +69,8 @@ class SubmitTestCase(unittest.TestCase):
         self.login()
 
         res = self.client.get(url_for('create_project'))
-        fields = ['form', 'input', 'URI', 'Name', 'Slugs', 'Members',
-                  'Managers', 'Spectators']
+        fields = ['form', 'input', 'URI', 'Name', 'Slugs', 'Default Activity',
+                  'Members', 'Managers', 'Spectators']
 
         for field in fields:
             assert field in res.get_data()

--- a/tests/test_edit_project.py
+++ b/tests/test_edit_project.py
@@ -56,6 +56,7 @@ class SubmitTestCase(unittest.TestCase):
             uri="http://github.com",
             name="Github",
             slugs="git, hub, gh",
+            default_activity="development",
             users="{'tschuy': {'member': True, 'spectator': False, 'manager': \
                 True}}"
         ), follow_redirects=True)
@@ -93,7 +94,8 @@ class SubmitTestCase(unittest.TestCase):
         self.admin_login()
 
         res = self.client.get(url_for('edit_project'))
-        fields = ['uri', 'name', 'slugs', 'members', 'managers', 'spectators']
+        fields = ['uri', 'name', 'slugs', 'default_activity', 'members',
+                  'managers', 'spectators']
 
         print res.get_data()
         for field in fields:


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #127 
Blocked by #135 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Added fields to add/edit a project's default activity and added a table column on `/projects` to see each project's default activity
- [X] When you select a project with a default activity on the create/edit time view, the project's default activity will automatically be selected in the activity selection box
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Make sure `TIMESYNC_URL` is set to `http://timesync-staging.osuosl.org/v0` in config.py
3. Run the app and log in as `admin`/`timesync-staging`
4. Go to `/projects` and see that "Default Activity" is a table column. Edit a project, add a default activity, and see that that default activity is shown in the column
5. Go to `/times/create` and select a project with a default activity in the project selection box. See that the project's default activity is selected in the activity selection box below. Select another project and see that the activity is deselected
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
14:31 $ nosetests
................................................................................................................................
----------------------------------------------------------------------
Ran 128 tests in 10.529s

OK
```

@osuosl/devs
