### PR TITLE
Catch TimeSync errors before summarizing times

### DIFF
--- a/app/views/view_times.py
+++ b/app/views/view_times.py
@@ -56,32 +56,33 @@ def view_times():
 
         times = ts.get_times(query_parameters=query)
 
-        # Generate summary information
-        total_time = 0
-        unique_users = set()
-        unique_projects = set()
-        unique_activities = list()
-        for entry in times:
-            total_time += entry['duration']
-            unique_users.add(entry['user'])
-            unique_projects.add(entry['project'][0])
-            unique_activities += entry['activities']
-
-        summary['total_time'] = (total_time)
-        summary['unique_users'] = len(unique_users)
-        summary['users_list'] = list(unique_users)
-        summary['unique_projects'] = len(unique_projects)
-        summary['projects_list'] = list(unique_projects)
-        summary['unique_activities'] = len(set(unique_activities))
-        summary['activities_list'] = list(set(unique_activities))
-
         # Show any errors
         if error_message(times):
             times = list()
 
+        # Generate summary information
+        if times:
+            total_time = 0
+            unique_users = set()
+            unique_projects = set()
+            unique_activities = list()
+            for entry in times:
+                total_time += entry['duration']
+                unique_users.add(entry['user'])
+                unique_projects.add(entry['project'][0])
+                unique_activities += entry['activities']
+
+            summary['total_time'] = (total_time)
+            summary['unique_users'] = len(unique_users)
+            summary['users_list'] = list(unique_users)
+            summary['unique_projects'] = len(unique_projects)
+            summary['projects_list'] = list(unique_projects)
+            summary['unique_activities'] = len(set(unique_activities))
+            summary['activities_list'] = list(set(unique_activities))
+
     # If the form's parameters are not valid, tell the user
     elif request.method == 'POST' and not form.validate():
-        flash("Invalid form input")
+        flash('Invalid form input')
 
     # Lines 87 and 89 were causing the times to show up by default regardless
     # of whether the form had been submitted or not.


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #66 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] Properly catch and handle TimeSync errors in `view_times`
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run the app, log in as `admin`/`admin` using `Password` login, and go to `/times`
3. Enter an invalid username in the `User` field, and click Submit. See that an error is flashed at the top of the screen.
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
10:12 $ nosetests
................................................................................................................................
----------------------------------------------------------------------
Ran 128 tests in 3.321s

OK
```

@osuosl/devs
