### PR TITLE
Fix links on admin page and removed 'Delete User' link

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -12,11 +12,9 @@
     </nav>
 
     <div class="menu">
-        {# TODO: Use url_for() when pages are implemented #}
-        <a href="/users/create">Create User</a>
-        <a href="/users">Get User</a>
-        <a href="/users/edit">Update User</a>
-        <a href="/users/delete">Delete User</a>
+        <a href="{{ url_for('create_user') }}">Create User</a>
+        <a href="{{ url_for('view_users') }}">Get User</a>
+        <a href="{{ url_for('edit_user') }}">Update User</a>
         <br />
         <a href="{{ url_for('create_activity') }}">Create Activity</a>
         <a href="{{ url_for('view_activities') }}">View Activities</a>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -81,7 +81,7 @@ class AdminTestCase(unittest.TestCase):
         """Test the admin page for correct links."""
         self.adminLogin()
 
-        links = ['Create User', 'Get User', 'Update User', 'Delete User']
+        links = ['Create User', 'Get User', 'Update User']
 
         res = self.client.get(url_for('admin'))
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->

Fixes #143 
## Changes in this PR.

<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->
- [X] `*_user` links now use `url_for` instead of hardcoded URLs
- [X] Removed "Delete User" link
## Testing this PR.

<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->
1. Run `nosetests`
2. Run the app with `docker-compose up` and log in as `admin`/`admin`
3. Go to `/admin` and see that the "User" links work and that "Delete User" no longer exists
### Expected Output.

<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ nosetests
...................................................................................................................................
----------------------------------------------------------------------
Ran 131 tests in 1.825s

OK
```

@osuosl/devs
