### PR TITLE
Added soft delete checks to view pages

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -108,6 +108,9 @@ class FilterTimesForm(Form):
                       description='yyyy-mm-dd', validators=[Optional()])
     end = DateField('End Date:', format="%Y-%m-%d",
                     description='yyyy-mm-dd', validators=[Optional()])
+    include_deleted = BooleanField('Include Deleted', validators=[Optional()])
+    include_revisions = BooleanField('Include Revisions',
+                                     validators=[Optional()])
 
 
 class CreateActivityForm(Form):
@@ -135,6 +138,9 @@ class FilterProjectsForm(Form):
 class FilterActivitiesForm(Form):
     # Optional
     slug = StringField('Activity Slug:')
+    include_deleted = BooleanField('Include Deleted', validators=[Optional()])
+    include_revisions = BooleanField('Include Revisions',
+                                     validators=[Optional()])
 
 
 class CreateUserForm(Form):

--- a/app/templates/view_activities.html
+++ b/app/templates/view_activities.html
@@ -35,7 +35,7 @@
             <tbody>
                 {% for a in activities %}
                 <tr>
-                {% if is_admin %}
+                {% if is_admin and not a['deleted_at'] %}
                     <td><a href="{{ url_for('delete_activity', slug=a['slug']) }}">DELETE</a></td>
                     <td><a href="{{ url_for('edit_activity', slug=a['slug']) }}">EDIT</a></td>
                 {% else %}

--- a/app/templates/view_activities.html
+++ b/app/templates/view_activities.html
@@ -12,6 +12,8 @@
         <form method="POST">
             {{ form.csrf_token }}
             <p>{{ form.slug.label }} {{ form.slug }}</p>
+            <p>{{ form.include_deleted }} {{ form.include_deleted.label }}</p>
+            <p>{{ form.include_revisions }} {{ form.include_revisions.label }}</p>
             <p>
                 <input class="btn waves-effect waves-light" type="submit" value="Submit">
                 <input class="btn waves-effect waves-light" type="button" name="clear" value="Clear" onclick="clearForm(this.form);">

--- a/app/templates/view_projects.html
+++ b/app/templates/view_projects.html
@@ -22,7 +22,7 @@
         var perPage = 10;
 
         addPagination(tableSelector, perPage);
-        makeSortable(tableSelector, perPage, 0, "asc");
+        makeSortable(tableSelector, perPage, 1, "asc");
     });
 </script>
 {% endblock %}
@@ -62,7 +62,7 @@
 
             {% for p in projects %}
             <tr>
-                {% if is_admin or user['username'] in p['managers'] %}
+                {% if (is_admin or user['username'] in p['managers']) and not p['deleted_at'] %}
                     <td><a href="{{ url_for('delete_project', slug=p['slugs'][0]) }}">DELETE</a></td>
                     <td><a href="{{ url_for('edit_project', project=p['slugs'][0]) }}">EDIT</a></td>
                 {% else %}

--- a/app/templates/view_times.html
+++ b/app/templates/view_times.html
@@ -16,6 +16,8 @@
             <p>{{ form.activities.label }} {{ form.activities }} {{ form.activities.description}} </p>
             <p>{{ form.start.label }} {{ form.start(class="datepicker", type="date") }}</p>
             <p>{{ form.end.label }} {{ form.end(class="datepicker", type="date") }}</p>
+            <p>{{ form.include_deleted }} {{ form.include_deleted.label }}</p>
+            <p>{{ form.include_revisions }} {{ form.include_revisions.label }}</p>
             <p>
                 <input class="btn waves-effect waves-light" type="submit" value="Submit">
                 <input class="btn waves-effect waves-light" type="button" name="clear" value="Clear" onclick="clearForm(this.form, false);">

--- a/app/templates/view_times.html
+++ b/app/templates/view_times.html
@@ -78,7 +78,7 @@
             <tbody>
                 {% for t in times %}
                 <tr>
-                    {% if t['user'] == user['username'] or is_admin %}
+                    {% if (t['user'] == user['username'] or is_admin) and not t['deleted_at'] %}
                         <td><a href="{{ url_for('delete_time', uuid=t['uuid']) }}">DELETE</a></td>
                         <td><a href="{{ url_for('edit_time', uuid=t['uuid']) }}">EDIT</a></td>
                     {% else %}

--- a/app/templates/view_user_times.html
+++ b/app/templates/view_user_times.html
@@ -45,7 +45,7 @@
             <tbody>
                 {% for t in times %}
                 <tr>
-                    {% if t['user'] == user or is_admin %}
+                    {% if (t['user'] == user or is_admin) and not t['deleted_at'] %}
                         <td><a href="{{ url_for('delete_time', uuid=t['uuid']) }}">DELETE</a></td>
                         <td><a href="{{ url_for('edit_time', uuid=t['uuid']) }}">EDIT</a></td>
                     {% else %}

--- a/app/views/view_activities.py
+++ b/app/views/view_activities.py
@@ -1,4 +1,4 @@
-from flask import session, redirect, url_for, request, render_template
+from flask import session, redirect, url_for, request, render_template, flash
 from app import app, forms
 import pymesync
 from app.util import is_logged_in, error_message, decrypter
@@ -37,6 +37,11 @@ def view_activities():
             query["include_deleted"] = include_deleted
         if include_revisions:
             query["include_revisions"] = include_revisions
+
+    if 'slug' in query and 'include_deleted' in query:
+        flash('Invalid query: Cannot use "Activity Slug" and "Include Deleted" \
+               at the same time')
+        query = {}
 
     activities = ts.get_activities(query_parameters=query)
 

--- a/app/views/view_activities.py
+++ b/app/views/view_activities.py
@@ -27,10 +27,16 @@ def view_activities():
     query = {}
 
     if form.validate_on_submit():
-        req_form = request.form
-        slug = req_form["slug"]
+        slug = form.slug.data
+        include_deleted = form.include_deleted.data
+        include_revisions = form.include_revisions.data
 
-        query["slug"] = slug
+        if slug:
+            query["slug"] = slug
+        if include_deleted:
+            query["include_deleted"] = include_deleted
+        if include_revisions:
+            query["include_revisions"] = include_revisions
 
     activities = ts.get_activities(query_parameters=query)
 

--- a/app/views/view_projects.py
+++ b/app/views/view_projects.py
@@ -31,7 +31,8 @@ def view_projects():
         flash("Invalid form input")
 
     if 'slug' in query and 'include_deleted' in query:
-        flash("Cannot have slug and include deleted filtered at the same time")
+        flash('Invalid query: Cannot use "Slug" and "Include Deleted" at the \
+               same time')
         query = {}
 
     projects = ts.get_projects(query_parameters=query)

--- a/app/views/view_times.py
+++ b/app/views/view_times.py
@@ -50,6 +50,8 @@ def view_times():
         activities = form.activities.data
         start = form.start.data
         end = form.end.data
+        include_deleted = form.include_deleted.data
+        include_revisions = form.include_revisions.data
 
         # Only using filter parameters that have been supplied
         if username:
@@ -62,6 +64,10 @@ def view_times():
             query['start'] = [start]
         if end:
             query['end'] = [end]
+        if include_deleted:
+            query['include_deleted'] = include_deleted
+        if include_revisions:
+            query['include_revisions'] = include_revisions
 
         times = ts.get_times(query_parameters=query)
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #166 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] If an object has been soft deleted, don't show the option to edit or delete it

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Run `flake8 app tests` and `nosetests`
2. Start the app with `docker-compose up`, then log in as "admin"/"admin", create and delete an activity, and select "Include Deleted" on the view activities page
3. You should see that the activity appears but there aren't any links to edit or delete it.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ nosetests
..............................................................................................................................
----------------------------------------------------------------------
Ran 126 tests in 3.190s

OK
```

@osuosl/devs
